### PR TITLE
Add null transformation for NAP to AGRS2010 height outisde nlgeo2018

### DIFF
--- a/nl_nsgi.sql
+++ b/nl_nsgi.sql
@@ -547,7 +547,7 @@ VALUES
         'EPSG',
         '8666',
         'Geoid (height correction) model file',
-        'nlgeo2018.gtx',
+        'nlgeo2018.gtx,null',
         NULL,
         NULL,
         NULL,


### PR DESCRIPTION
De transformatie tussen NAP en ellipsoïdische hoogte voor AGRS2010 is alleen mogelijk binnen de grenzen van het hoogtecorrectiegrid van NLGEO2018, dat onderdeel is van RDNAPTRANS™2018.

Bij gebruik van PROJ (csc2cs) kan hierdoor buiten de grenzen van dit grid geen 3D transformatie gedaan tussen het samengestelde coördinaatreferentiesysteem RDNAP en AGRS2010. Het gedrag van cs2cs is namelijk als volgt:

| Transformatie RDNAP \< - \> AGRS2010 | Invoer | Uitvoer bij 3D CRS | Uitvoer bij 2D CRS |
| -------------------------------------------- | ------- | -------------------- | --------------------- |
| Binnen grid | 3D | 3D | 2D |
|                     | 2D | 2D, [h \| H] = 0  | 2D | 
| Buiten grid | 3D | Geen uitvoer | 2D |
|                     | 2D | 2D, [h \| H] = 0  | 2D | 

Voorbeeld

```
cs2cs -d 4 --no-ballpark NSGI:AGRS2010_GEOGRAPHIC_2D EPSG:7415 <<< "2 2"
-303977.8041    -5471504.9711 0.0000

cs2cs -d 4 --no-ballpark NSGI:AGRS2010_GEOGRAPHIC_3D EPSG:7415 <<< "2 2 43"
*       * inf

cs2cs -d 4 --no-ballpark EPSG:9000 EPSG:7415 <<< "89 179 43 2024.0"
168754.7700     4967816.6873 42.9217 2024.0

cs2cs -d 4 --no-ballpark EPSG:7912 EPSG:7415 <<< "89 179 43 2024.0"
*       * inf 2024.0

```

- Bij 3D invoer en 3D uitvoer binnen het grid is er geen probleem.
- Bij 3D invoer en 3D uitvoer buiten het grid komen er geen getransformeerde coördinaten terug.
- Bij 2D uitvoer wordt de hoogte niet getransformeerd en is het geen probleem als punten buiten het grid vallen.
- Bij 2D invoer en 3D uitvoer introduceert PROJ zelf een hoogte met waarde 0.0. Dit is opmerkelijk gedrag.

RDNAP is een samengesteld CRS. De transformatie tussen RD en AGRS2010 is een 2D-transformatie die ook buiten het hoogtecorrectiegrid mogelijk is. Vanuit gebruiksvriendelijkheid willen we buiten het grid altijd de resultaten van de 2D transformatie teruggeven. Dit is mogelijk door in de PROJ database _',null'_ aan de string van het grid dat wordt opgegeven bij de '_vgridshift'_ methode, wordt een nultransformatie toegepast voor de hoogte. Het gedrag van cs2cs wordt dan:

| Transformatie RDNAP \< - \> AGRS2010 | Invoer | Uitvoer bij 3D CRS | Uitvoer bij 2D CRS |
| -------------------------------------------- | ------- | -------------------- | --------------------- |
| Binnen grid | 3D | 3D | 2D |
|                     | 2D | 2D, [h \| H] = 0  | 2D | 
| Buiten grid | 3D | 2D, [h \| H] = [H \| h] | 2D |
|                     | 2D | 2D, [h \| H] = 0  | 2D | 

Voorbeeld

```
cs2cs -d 4 --no-ballpark NSGI:AGRS2010_GEOGRAPHIC_2D EPSG:7415 <<< "2 2"
-303977.8041    -5471504.9711 0.0000

cs2cs -d 4 --no-ballpark NSGI:AGRS2010_GEOGRAPHIC_3D EPSG:7415 <<< "2 2 43"
-303977.8041    -5471504.9711 43.0000

cs2cs -d 4 --no-ballpark EPSG:9000 EPSG:7415 <<< "89 179 43 2024.0"
168754.7700     4967816.6873 42.9217 2024.0

cs2cs -d 4 --no-ballpark EPSG:7912 EPSG:7415 <<< "89 179 43 2024.0"
168754.7700     4967816.6873 42.9217 2024.0

```

Dit gedrag is gebruiksvriendelijk, maar mogelijk verwarrend doordat bij een transformatie naar een 3D CRS:

- Bij 2D invoer een hoogte 0.0 wordt geïntroduceerd.
- Bij 3D invoer buiten het grid een nultransformatie voor de hoogte wordt uitgevoerd. Gebruikers zouden 0.0 kunnen verwachten in deze situatie.

Het eerste punt is dus standaard gedrag van PROJ, het tweede punt komt door onze toevoeging van _',null'_. Bij de documentatie van de PROJ-database die we leveren moet dit gedrag goed worden gedocumenteerd, zodat gebruikers hier kennis van kunnen nemen.

**Gewenst gedrag van de API**

Wanneer een hoogtetransformatie niet mogelijk is, moet ook geen hoogte worden teruggeven. 

| Transformatie RDNAP \< - \> AGRS2010 | Invoer | Uitvoer bij 3D geografisch of samengesteld CRS | Uitvoer bij 3D geocentrisch CRS | Uitvoer bij 2D CRS |
| -------------------------------------------- | ------- | ---------|----------- | --------------------- |
| Binnen grid | 3D | 3D | 3D |2D |
|                     | 2D | 2D, geen hoogte uitoer $${\color{red}beter: Geen uitvoer}$$ | Geen uitvoer | 2D | 
| Buiten grid | 3D | 2D, geen hoogte uitoer  | Geen uitvoer | 2D |
|                     | 2D | 2D, geen hoogte uitoer $${\color{red}beter: Geen uitvoer}$$ | Geen uitvoer| 2D | 


Dit betekent in woorden:

- Bij 2D invoer en 3D uitvoer: Geen transformatie uitvoeren.
- Bij 3D invoer buiten het grid en 3D geografische uitvoer: : Geen hoogte teruggeven
- Bij 3D invoer buiten het grid en 3D geocentrische uitvoer: : Geen resultaat teruggeven

Het tweede geval kan eenvoudig op de volgende manieren worden gedetecteerd:

- Controle of de geografische AGRS2010-coördinaten buiten het grid vallen
- Controle of de ellipsoïdische AGRS2010-hoogte en NAP-hoogte na transformatie minder dan 0.5 of 10 (?) meter verschillen.

Beide tests zijn dus alleen mogelijk bij geografische coördinaten. Bij uitvoer van geocentrische uitvoer moeten om de test te kunnen uitvoeren geografische coördinaten beschikbaar zijn. Dit kan als volgt worden geïmplementeerd

- Transformeer bij geocentrische uitvoer altijd eerst naar geografisch, voer de test uit, transformeer alleen de coördinaten met een hoogte naar geocentrisch. Geef de overige punten geen coördinaten.
- Transformeer de geocentrische uitvoer naar geografisch, voer de test uit, verwijder coördinaten voor punten zonder hoogte.